### PR TITLE
Handle more complex id patterns

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -164,7 +164,7 @@ internals.buildPath = function (resultsData, pos, parts) {
             break;
         }
 
-        if (!/^[\w:]+$/.test(value)) {
+        if (!/^([\w:](-?|\.?))+$/.test(value)) {
             error = new Error('Reference value includes illegal characters');
             break;
         }
@@ -173,6 +173,7 @@ internals.buildPath = function (resultsData, pos, parts) {
 
     }
 
+    //console.log("built path:", error ? error : path);
     return error ? error : path;
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bassmaster",
   "description": "Batch processing plugin for hapi",
   "repository": "git://github.com/hapijs/bassmaster",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "lib/index.js",
   "keywords": [
     "hapi",

--- a/test/batch.js
+++ b/test/batch.js
@@ -203,6 +203,39 @@ describe('Batch', () => {
         });
     });
 
+    it('supports piping Id\'s with "-" (like a uuid) into the next request', (done) => {
+
+        Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/interestingIds"}, {"method": "get", "path": "/item/$0.idWithDash"}] }', (res) => {
+
+            expect(res.length).to.equal(2);
+            expect(res[0].idWithDash).to.equal('55cf-687663-55cf687663');
+            expect(res[1].id).to.equal('55cf-687663-55cf687663');
+            done();
+        });
+    });
+
+    it('supports piping interesting Ids with "." (like a filename) into the next request', (done) => {
+
+        Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/interestingIds"}, {"method": "get", "path": "/item/$0.idLikeFilename"}] }', (res) => {
+
+            expect(res.length).to.equal(2);
+            expect(res[0].idLikeFilename).to.equal('55cf687663.png');
+            expect(res[1].id).to.equal('55cf687663.png');
+            done();
+        });
+    });
+
+    it('supports piping interesting Ids with "-" and "." (like a filename) into the next request', (done) => {
+
+        Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/interestingIds"}, {"method": "get", "path": "/item/$0.idLikeFileNameWithDash"}] }', (res) => {
+
+            expect(res.length).to.equal(2);
+            expect(res[0].idLikeFileNameWithDash).to.equal('55cf-687663-55cf687663.png');
+            expect(res[1].id).to.equal('55cf-687663-55cf687663.png');
+            done();
+        });
+    });
+
     it('supports piping a deep response into the next request', (done) => {
 
         Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/deepItem"}, {"method": "post", "path": "/echo", "payload": "$0.inner.name"}, {"method": "post", "path": "/echo", "payload": "$0.inner.inner.name"}, {"method": "post", "path": "/echo", "payload": "$0.inner.inner.inner.name"}] }', (res) => {

--- a/test/batch.js
+++ b/test/batch.js
@@ -203,6 +203,32 @@ describe('Batch', () => {
         });
     });
 
+    it('supports piping a deep response into the next request', (done) => {
+
+        Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/deepItem"}, {"method": "post", "path": "/echo", "payload": "$0.inner.name"}, {"method": "post", "path": "/echo", "payload": "$0.inner.inner.name"}, {"method": "post", "path": "/echo", "payload": "$0.inner.inner.inner.name"}] }', (res) => {
+
+            expect(res.length).to.equal(4);
+            expect(res[0].id).to.equal('55cf687663');
+            expect(res[0].name).to.equal('Deep Item');
+            expect(res[1]).to.equal('Level 1');
+            expect(res[2]).to.equal('Level 2');
+            expect(res[3]).to.equal('Level 3');
+            done();
+        });
+    });
+
+    it('supports piping a deep response into an array in the next request', (done) => {
+
+        Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/deepItem"}, {"method": "post", "path": "/echo", "payload": "$0.inner.inner.inner.array.0.name"}] }', (res) => {
+
+            expect(res.length).to.equal(2);
+            expect(res[0].id).to.equal('55cf687663');
+            expect(res[0].name).to.equal('Deep Item');
+            expect(res[1]).to.equal('Array Item 0');
+            done();
+        });
+    });
+
     it('supports piping integer response into the next request', (done) => {
 
         Internals.makeRequest(server, '{ "requests": [ {"method": "get", "path": "/int"}, {"method": "get", "path": "/int/$0.id"}] }', (res) => {

--- a/test/internals.js
+++ b/test/internals.js
@@ -122,6 +122,15 @@ const redirectHandler = function (request, reply) {
     return reply().redirect('/profile');
 };
 
+const interestingIdsHandler = function (request, reply) {
+
+    return reply({
+        'idWithDash': '55cf-687663-55cf687663',
+        'idLikeFilename': '55cf687663.png',
+        'idLikeFileNameWithDash': '55cf-687663-55cf687663.png'
+    });
+};
+
 const fetch1 = function (request, next) {
 
     next('Hello');
@@ -182,6 +191,7 @@ module.exports.setupServer = function (done) {
         { method: 'GET', path: '/int', handler: integerHandler },
         { method: 'GET', path: '/int/{id}', handler: integerItemHandler },
         { method: 'GET', path: '/string', handler: stringItemHandler },
+        { method: 'GET', path: '/interestingIds', handler: interestingIdsHandler },
         { method: 'GET', path: '/error', handler: errorHandler },
         { method: 'GET', path: '/badchar', handler: badCharHandler },
         { method: 'GET', path: '/badvalue', handler: badValueHandler },

--- a/test/internals.js
+++ b/test/internals.js
@@ -29,6 +29,31 @@ const itemHandler = function (request, reply) {
     });
 };
 
+const deepItemHandler = function (request, reply) {
+
+    return reply({
+        'id': '55cf687663',
+        'name': 'Deep Item',
+        'inner': {
+            'name': 'Level 1',
+            'inner': {
+                'name': 'Level 2',
+                'inner': {
+                    'name': 'Level 3',
+                    'array': [
+                        {
+                            'name': 'Array Item 0'
+                        },
+                        {
+                            'name': 'Array Item 1'
+                        }
+                    ]
+                }
+            }
+        }
+    });
+};
+
 const item2Handler = function (request, reply) {
 
     return reply({
@@ -149,6 +174,7 @@ module.exports.setupServer = function (done) {
         { method: 'PUT', path: '/echo', handler: echoHandler },
         { method: 'GET', path: '/profile', handler: profileHandler },
         { method: 'GET', path: '/item', handler: activeItemHandler },
+        { method: 'GET', path: '/deepItem', handler: deepItemHandler },
         { method: 'GET', path: '/array', handler: arrayHandler },
         { method: 'GET', path: '/item/{id}', handler: itemHandler },
         { method: 'GET', path: '/item2/{id?}', handler: item2Handler },


### PR DESCRIPTION
Updated a validation regex to add support for Id's which contain dashes (like uuid's) and dots (like file names).
So id's like `55cf-687663-55cf687663.png` can now be piped from responses to other requests in the batch.